### PR TITLE
check for current players before shutting down

### DIFF
--- a/server-state/index.js
+++ b/server-state/index.js
@@ -13,6 +13,12 @@ const servers = new Map([
     ["2", "i-043822a6585ffc35b"]
 ]);
 
+const fetch = require("node-fetch");
+
+const statusServiceUrl = "https://ek2ta6hpv0.execute-api.us-east-2.amazonaws.com/Stage/valhalla/servers/{serverId}/state"
+
+const noContentResponse = { "statusCode": 204 };
+
 exports.handler = async function(event, context) {
 
     const serverId = event.pathParameters.serverId;
@@ -30,14 +36,7 @@ exports.handler = async function(event, context) {
             console.log("Received an invalid path parameter, exiting...");
     }
 
-    let response = {
-        "statusCode": 204,
-        "headers": {
-            "Access-Control-Allow-Origin": "*"
-        }
-    };
-
-    return response;
+    return noContentResponse;
 }
 
 async function startServer(serverId) {
@@ -52,22 +51,32 @@ async function startServer(serverId) {
 }
 
 async function stopServer(serverId) {
-    const params = {
-        InstanceIds: [
-            servers.get(serverId)
-        ]
-    }
 
-    console.log("Stopping instance " + params.InstanceIds[0]);
-    await ec2client.send(new StopInstancesCommand(params))
+    const numPlayers = await fetch(statusServiceUrl.replace("{serverId}", serverId))
+        .then(response => response.json())
+        .then(json => {
+            return json.numPlayers
+        });
+        
+    if (numPlayers === 0) {
+        const params = {
+            InstanceIds: [
+                servers.get(serverId)
+            ]
+        }
+
+        console.log(`Stopping instance ${params.InstanceIds[0]}`);
+        await ec2client.send(new StopInstancesCommand(params));
+    } else {
+        console.log(`The server won't terminate because there are ${numPlayers} currently playing`);
+    }
 }
 
 var formatError = function(error, statusCode) {
     return {
         "statusCode": statusCode,
         "headers": {
-            "Content-Type": "application/json",
-            "Access-Control-Allow-Origin": "*"
+            "Content-Type": "application/json"
         },
         "body": error.message
     }


### PR DESCRIPTION
Enable check for active players before shutting down a server. Also removes the CORS header because it's now handled in API Gateway.